### PR TITLE
Add setting to disable FAA flight rules display

### DIFF
--- a/com.neil-enns.vatis.sdPlugin/images/actions/atisLetter/template.svg
+++ b/com.neil-enns.vatis.sdPlugin/images/actions/atisLetter/template.svg
@@ -22,16 +22,18 @@
 	</defs>
 
 	<rect class="background" width="144" height="144"/>
-	{{#if (eq faaFlightRules "VFR")}}
-		<circle cx="18" cy="27" r="10" fill="#28a745" />
-	{{else if (eq faaFlightRules "MVFR")}}
-		<rect x="12" y="20" width="18" height="18" fill="#0080f0" />
-	{{else if (eq faaFlightRules "IFR")}}
-		<polygon points="18,17 8,37 28,37" fill="#dc3545" />
-	{{else if (eq faaFlightRules "LIFR")}}
-		<polygon points="18,16 8,27 18,38 28,27" fill="#9722ce" />
+	{{#if showFaaFlightRules}}
+		{{#if (eq faaFlightRules "VFR")}}
+			<circle cx="18" cy="27" r="10" fill="#28a745" />
+		{{else if (eq faaFlightRules "MVFR")}}
+			<rect x="12" y="20" width="18" height="18" fill="#0080f0" />
+		{{else if (eq faaFlightRules "IFR")}}
+			<polygon points="18,17 8,37 28,37" fill="#dc3545" />
+		{{else if (eq faaFlightRules "LIFR")}}
+			<polygon points="18,16 8,27 18,38 28,27" fill="#9722ce" />
+		{{/if}}
 	{{/if}}
-
+	
 	<text class="displayText" x="72" y="36" font-family="Verdana" font-weight="bold" font-size="22"
 		text-anchor="middle">{{title}}</text>
 	<text class="displayText" x="72" y="92" font-family="Verdana" font-weight="bold" font-size="50"

--- a/com.neil-enns.vatis.sdPlugin/ui/atisLetter.html
+++ b/com.neil-enns.vatis.sdPlugin/ui/atisLetter.html
@@ -33,6 +33,14 @@
       </sdpi-select>
     </sdpi-item>
 
+    <sdpi-item>
+      <sdpi-checkbox
+        setting="showFaaFlightRules"
+        label="Show FAA flight rules indicator"
+        default="true"
+      ></sdpi-checkbox>
+    </sdpi-item>
+
     <sdpi-item label="Current">
       <sdpi-file
         setting="currentImagePath"

--- a/src/actions/atisLetter.ts
+++ b/src/actions/atisLetter.ts
@@ -88,6 +88,7 @@ export interface AtisLetterSettings {
   showWind?: boolean;
   currentImagePath?: string;
   observerImagePath?: string;
+  showFaaFlightRules?: boolean;
   showLetter?: boolean;
   showTitle?: boolean;
   station?: string;

--- a/src/controllers/atisLetter.ts
+++ b/src/controllers/atisLetter.ts
@@ -125,6 +125,14 @@ export class AtisLetterController extends BaseController {
   }
 
   /**
+   * Gets the show FAA flight rules setting.
+   * @returns {boolean} True if the flight rules indicator should show. Defaults to true if no setting is provided.
+   */
+  get showFaaFlightRules(): boolean {
+    return this.settings.showFaaFlightRules ?? true;
+  }
+
+  /**
    * Gets the FAA flight rules for the current ATIS.
    * @returns {FaaFlightRules} The current FAA flight rules.
    */
@@ -395,63 +403,6 @@ export class AtisLetterController extends BaseController {
   }
 
   /**
-   * Disables automatic refreshing of the title and background image when
-   * properties are updated. Useful when multiple properties will be updated
-   * in quick succession to avoid unnecessary re-renders.
-   */
-  public suppressUpdates() {
-    this._suppressUpdates = true;
-  }
-
-  /**
-   * Enables automatic refreshing of the title and background image when
-   * properties are updated.
-   */
-  public enableUpdates() {
-    this._suppressUpdates = false;
-  }
-
-  /**
-   * Sets the image based on the state of the action.
-   */
-  private refreshImage() {
-    const replacements = {
-      connectionStatus: this.connectionStatus,
-      isConnected:
-        this.connectionStatus === NetworkConnectionStatus.Connected ||
-        NetworkConnectionStatus.Observer,
-      isNewAtis: this.isNewAtis,
-      letter: this.letter,
-      pressure: {
-        unit: this.pressure?.actualUnit,
-        value: this.pressure?.actualValue,
-        formattedValue: this.altimeter,
-      },
-      station: this.station,
-      title: this.title,
-      wind: this.wind,
-      faaFlightRules: this.faaFlightRules,
-    };
-
-    if (this.isNewAtis) {
-      this.setImage(this.updatedImagePath, replacements);
-      return;
-    }
-
-    if (this.connectionStatus === NetworkConnectionStatus.Connected) {
-      this.setImage(this.currentImagePath, replacements);
-      return;
-    }
-
-    if (this.connectionStatus === NetworkConnectionStatus.Observer) {
-      this.setImage(this.observerImagePath, replacements);
-      return;
-    }
-
-    this.setImage(this.unavailableImagePath, replacements);
-  }
-
-  /**
    * Calculates FAA flight rules based on ceiling and visibility values.
    * @param {Value | undefined} ceiling - The ceiling height in hundreds of feet.
    * @param {Value | undefined} prevailingVisibility - The visibility in statute miles.
@@ -512,6 +463,64 @@ export class AtisLetterController extends BaseController {
     } else {
       this.faaFlightRules = FaaFlightRules.UNKNOWN;
     }
+  }
+
+  /**
+   * Disables automatic refreshing of the title and background image when
+   * properties are updated. Useful when multiple properties will be updated
+   * in quick succession to avoid unnecessary re-renders.
+   */
+  public suppressUpdates() {
+    this._suppressUpdates = true;
+  }
+
+  /**
+   * Enables automatic refreshing of the title and background image when
+   * properties are updated.
+   */
+  public enableUpdates() {
+    this._suppressUpdates = false;
+  }
+
+  /**
+   * Sets the image based on the state of the action.
+   */
+  private refreshImage() {
+    const replacements = {
+      connectionStatus: this.connectionStatus,
+      isConnected:
+        this.connectionStatus === NetworkConnectionStatus.Connected ||
+        NetworkConnectionStatus.Observer,
+      isNewAtis: this.isNewAtis,
+      letter: this.letter,
+      pressure: {
+        unit: this.pressure?.actualUnit,
+        value: this.pressure?.actualValue,
+        formattedValue: this.altimeter,
+      },
+      station: this.station,
+      title: this.title,
+      wind: this.wind,
+      faaFlightRules: this.faaFlightRules,
+      showFaaFlightRules: this.showFaaFlightRules,
+    };
+
+    if (this.isNewAtis) {
+      this.setImage(this.updatedImagePath, replacements);
+      return;
+    }
+
+    if (this.connectionStatus === NetworkConnectionStatus.Connected) {
+      this.setImage(this.currentImagePath, replacements);
+      return;
+    }
+
+    if (this.connectionStatus === NetworkConnectionStatus.Observer) {
+      this.setImage(this.observerImagePath, replacements);
+      return;
+    }
+
+    this.setImage(this.unavailableImagePath, replacements);
   }
 
   /**


### PR DESCRIPTION
Fixes #75

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a toggle option to show/hide FAA flight rules indicator in ATIS Letter settings
  - Introduced a new checkbox in the user interface for FAA flight rules visibility

- **Improvements**
  - Enhanced configuration options for ATIS Letter display settings
  - Updated image refresh logic to incorporate new flight rules display setting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->