### PR TITLE
Not connected stations should show text in grey, not white

### DIFF
--- a/src/controllers/atisLetter.ts
+++ b/src/controllers/atisLetter.ts
@@ -491,7 +491,7 @@ export class AtisLetterController extends BaseController {
       connectionStatus: this.connectionStatus,
       isConnected:
         this.connectionStatus === NetworkConnectionStatus.Connected ||
-        NetworkConnectionStatus.Observer,
+        this.connectionStatus === NetworkConnectionStatus.Observer,
       isNewAtis: this.isNewAtis,
       letter: this.letter,
       pressure: {


### PR DESCRIPTION
Fixes #85

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved network connection status checking logic to ensure accurate connection state determination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->