### PR TITLE
Get rid of `isConnected` in atisLetter controller

### DIFF
--- a/src/controllers/atisLetter.ts
+++ b/src/controllers/atisLetter.ts
@@ -98,14 +98,6 @@ export class AtisLetterController extends BaseController {
 
   //#region Getters and setters
   /**
-   * Gets the isConnected state.
-   * @returns {boolean} True if the connection status is NetworkConnectionStatus.Connected.
-   */
-  get isConnected(): boolean {
-    return this._connectionStatus === NetworkConnectionStatus.Connected;
-  }
-
-  /**
    * Gets the connectionStatus.
    * @returns {NetworkConnectionStatus | undefined } The network connection status or undefined if no status is available.
    */


### PR DESCRIPTION
Fixes #87

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed a connection status check method from the ATIS letter controller

Note: This change may affect how connection state is verified in the application and might require updates in dependent code modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->