### PR TITLE
Upgrade to sdk v2 beta and enable DRM

### DIFF
--- a/com.neil-enns.vatis.sdPlugin/manifest.json
+++ b/com.neil-enns.vatis.sdPlugin/manifest.json
@@ -49,7 +49,7 @@
   "CodePath": "bin/plugin.js",
   "Description": "Provides actions for displaying current ATIS information from vATIS.",
   "Icon": "images/plugin/pluginIcon",
-  "SDKVersion": 2,
+  "SDKVersion": 3,
   "URL": "https://projects.neilenns.com/docs/streamdeck-vatis/",
   "Software": {
     "MinimumVersion": "6.9"

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@elgato/streamdeck": "^1.0.0",
+        "@elgato/streamdeck": "^2.0.0-beta",
         "chokidar": "^4.0.3",
         "debounce": "^2.2.0",
         "handlebars": "^4.7.8",
@@ -101,10 +101,9 @@
       "license": "MIT"
     },
     "node_modules/@elgato/streamdeck": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@elgato/streamdeck/-/streamdeck-1.4.1.tgz",
-      "integrity": "sha512-nk3TWfSvLrMWR6AhD6DG/pnJhWR6/xzP9elH/VLaiyZ27Nxb1Hu3rPuRty6xE5AZykwf3Auafok016wZSJZ3TA==",
-      "license": "MIT",
+      "version": "2.0.0-beta",
+      "resolved": "https://registry.npmjs.org/@elgato/streamdeck/-/streamdeck-2.0.0-beta.tgz",
+      "integrity": "sha512-3VxZn91PQJ9KAu6H9HzZZAxcQCBGoBBhGtqvdgJoMN4mmDp+tAAVWD2nYiHhGtGqQJ1Opcx0tXpUeLsYaffDKw==",
       "dependencies": {
         "@elgato/schemas": "^0.4.8",
         "ws": "^8.18.0"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "typescript-eslint": "^8.18.2"
   },
   "dependencies": {
-    "@elgato/streamdeck": "^1.0.0",
+    "@elgato/streamdeck": "^2.0.0-beta",
     "chokidar": "^4.0.3",
     "debounce": "^2.2.0",
     "handlebars": "^4.7.8",


### PR DESCRIPTION
Fixes #164

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated compatibility to Stream Deck SDK v3 to ensure support with the latest Stream Deck app.
  * Upgraded Stream Deck library dependency to the latest beta, improving compatibility and laying groundwork for future enhancements.
  * No functional changes expected; existing behavior should remain the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->